### PR TITLE
cartesian_prod for make_rays_2d

### DIFF
--- a/chapter0_fundamentals/instructions/pages/01_[0.1]_Ray_Tracing.py
+++ b/chapter0_fundamentals/instructions/pages/01_[0.1]_Ray_Tracing.py
@@ -863,7 +863,7 @@ Don't write it as a function right away. The most efficient way is to write and 
 
 You can either build up the output tensor using `torch.stack`, or you can initialize the output tensor to its final size and then assign to slices like `rays[:, 1, 1] = ...`. It's good practice to be able to do it both ways.
 
-Each y coordinate needs a ray with each corresponding z coordinate - in other words this is an outer product. The most elegant way to do this is with two calls to `einops.repeat`. You can also accomplish this with `unsqueeze`, `expand`, and `reshape` combined.
+Each y coordinate needs a ray with each corresponding z coordinate - more specifically, this is a cartesian product. The most elegant way to do this is with `torch.cartesian_prod`. Alternatively, you could use two calls to `einops.repeat`. You can also accomplish this with `unsqueeze`, `expand`, and `reshape` combined.
 </details>
 
 <details>

--- a/chapter0_fundamentals/instructions/pages/01_[0.1]_Ray_Tracing.py
+++ b/chapter0_fundamentals/instructions/pages/01_[0.1]_Ray_Tracing.py
@@ -883,12 +883,12 @@ def make_rays_2d(num_pixels_y: int, num_pixels_z: int, y_limit: float, z_limit: 
     '''
     # SOLUTION
     n_pixels = num_pixels_y * num_pixels_z
-    ygrid = t.linspace(-y_limit, y_limit, num_pixels_y)
-    zgrid = t.linspace(-z_limit, z_limit, num_pixels_z)
-    rays = t.zeros((n_pixels, 2, 3), dtype=t.float32)
-    rays[:, 1, 0] = 1
-    rays[:, 1, 1] = einops.repeat(ygrid, "y -> (y z)", z=num_pixels_z)
-    rays[:, 1, 2] = einops.repeat(zgrid, "z -> (y z)", y=num_pixels_y)
+    rays = t.zeros((n_pixels, 2, 3))
+    y_vals = t.linspace(-y_limit, y_limit, num_pixels_y)
+    z_vals = t.linspace(-z_limit, z_limit, num_pixels_z)
+
+    rays[:, 1] = t.cartesian_prod(t.ones((1,)), y_vals, z_vals)
+
     return rays
 ```
 </details>


### PR DESCRIPTION
I'm not sure that this solution is better, especially since it dodges a chance to practice with `einops`, but it does feel more elegant. If you agree that the einops solution should be kept, I can revert the code changes and reword the hint to just mention `cartesian_prod` as another option

p.s. 

I know, I know I'm super behind  -- I spent way more time than I should have trying (albeit successfully) to get pytorch / numpy working on my workstation after an unsuccessful experiment with nix.