### PR TITLE
Add Chapter 0, Autograd section backprop test

### DIFF
--- a/chapter0_fundamentals/exercises/part5_backprop/solutions.py
+++ b/chapter0_fundamentals/exercises/part5_backprop/solutions.py
@@ -634,6 +634,7 @@ if MAIN:
 	tests.test_backprop_branching(Tensor)
 	tests.test_backprop_requires_grad_false(Tensor)
 	tests.test_backprop_float_arg(Tensor)
+	tests.test_backprop_shared_parent(Tensor)
 
 # %% 3️⃣ MORE FORWARD & BACKWARD FUNCTIONS
 

--- a/chapter0_fundamentals/exercises/part5_backprop/tests.py
+++ b/chapter0_fundamentals/exercises/part5_backprop/tests.py
@@ -233,7 +233,6 @@ def test_backprop(Tensor):
     assert np.allclose(a.grad.array, 1 / b.array / a.array)
     print("All tests in `test_backprop` passed!")
 
-
 def test_backprop_branching(Tensor):
     a = Tensor([1, 2, 3], requires_grad=True)
     b = Tensor([1, 2, 3], requires_grad=True)
@@ -243,7 +242,6 @@ def test_backprop_branching(Tensor):
     assert np.allclose(b.grad.array, a.array)
     print("All tests in `test_backprop_branching` passed!")
 
-
 def test_backprop_requires_grad_false(Tensor):
     a = Tensor([1, 2, 3], requires_grad=True)
     b = Tensor([1, 2, 3], requires_grad=False)
@@ -252,7 +250,6 @@ def test_backprop_requires_grad_false(Tensor):
     assert np.allclose(a.grad.array, b.array)
     assert b.grad is None
     print("All tests in `test_backprop_requires_grad_false` passed!")
-
 
 def test_backprop_float_arg(Tensor):
     a = Tensor([1, 2, 3], requires_grad=True)
@@ -266,6 +263,19 @@ def test_backprop_float_arg(Tensor):
     assert a.grad is not None
     assert np.allclose(a.grad.array, np.array([4.0, 4.0, 4.0]))
     print("All tests in `test_backprop_float_arg` passed!")
+
+def test_backprop_shared_parent(Tensor):
+    a = 2
+    b = Tensor([1, 2, 3], requires_grad=True)
+    c = 3
+    d = a * b
+    e = b * c
+    f = d * e
+    f.backward(end_grad=np.array([1.0, 1.0, 1.0]))
+    assert f.grad is None
+    assert b.grad is not None
+    assert np.allclose(b.grad.array, np.array([12.0, 24.0, 36.0])), "Multiple nodes may have the same parent."
+    print("All tests in `test_backprop_shared_parent` passed!")
 
 def test_negative_back(Tensor):
     a = Tensor([-1.0, 0.0, 1.0], requires_grad=True)

--- a/chapter0_fundamentals/instructions/pages/05_[0.5]_Backprop.py
+++ b/chapter0_fundamentals/instructions/pages/05_[0.5]_Backprop.py
@@ -1772,6 +1772,7 @@ if MAIN:
     tests.test_backprop_branching(Tensor)
     tests.test_backprop_requires_grad_false(Tensor)
     tests.test_backprop_float_arg(Tensor)
+    tests.test_backprop_shared_parent(Tensor)
 
 ```
 


### PR DESCRIPTION
Going through the course now and just finished the backprop function. I realized that there were no tests to ensure that gradients were added if multiple nodes have the same parent.

To illustrate, the following code is in the solution:


            if parent not in grads:

                grads[parent] = in_grad

            else:

                grads[parent] += in_grad

If you were to replace that code with
`            grads[parent] = in_grad`

all of the current tests pass. The new test will throw an error, because it has a graph where b is the parent of both d and e.

This comes from going through the solution and not understanding at first why that addition was there! The course is great so far, thank you!

I believe a similar change is needed in the SERI-MATS-2023-Streamlit-pages repo, I'm happy to make a pull request there as well if this is approved.