### PR TITLE
Remove circuitsvis resizing bug notes (it's fixed)

### DIFF
--- a/chapter1_transformers/instructions/pages/03_[1.3]_Indirect_Object_Identification.py
+++ b/chapter1_transformers/instructions/pages/03_[1.3]_Indirect_Object_Identification.py
@@ -1010,31 +1010,6 @@ Reminder - you can use `attention_patterns` or `attention_heads` for these visua
 
 Try replacing `attention_patterns` above with `attention_heads`, and compare the output.
 
-<details>
-<summary>Help - my <code>attention_heads</code> plots are behaving weirdly.</summary>
-
-This seems to be a bug in `circuitsvis` - on VSCode, the attention head plots continually shrink in size.
-
-Until this is fixed, one way to get around it is to open the plots in your browser. You can do this inline with the `webbrowser` library:
-
-```python
-attn_heads = cv.attention.attention_heads(
-    attention = attn_patterns_for_important_heads,
-    tokens = model.to_str_tokens(tokens[0]),
-    attention_head_names = [f"{layer}.{head}" for layer, head in top_heads],
-)
-
-path = "attn_heads.html"
-
-with open(path, "w") as f:
-    f.write(str(attn_heads))
-
-webbrowser.open(path)
-```
-
-To check exactly where this is getting saved, you can print your current working directory with `os.getcwd()`.
-</details>
-
 From these plots, you might want to start thinking about the algorithm which is being implemented. In particular, for the attention heads with high positive attribution scores, where is `" to"` attending to? How might this head be affecting the logit diff score?
 
 We'll save a full hypothesis for how the model works until the end of the next section.


### PR DESCRIPTION
This bug is now resolved so the hint is no longer needed.

Thanks to @UFO-101 for fixing the underlying bug, and @luciaquirke for reviewing.