### PR TITLE
Update 02_[1.2]_Intro_to_Mech_Interp.py

### DIFF
--- a/chapter1_transformers/instructions/pages/02_[1.2]_Intro_to_Mech_Interp.py
+++ b/chapter1_transformers/instructions/pages/02_[1.2]_Intro_to_Mech_Interp.py
@@ -2817,6 +2817,8 @@ def mask_scores(attn_scores: Float[Tensor, "query_nctx key_nctx"]):
     return masked_attn_scores
 
 
+layer = 0
+head_index = 7
 
 # YOUR CODE HERE - calculate the matrix `pos_by_pos_pattern` as described above
 tests.test_pos_by_pos_pattern(pos_by_pos_pattern, model, layer, head_index)


### PR DESCRIPTION
Specify `layer` and `head_index` to avoid the test failing because those weren't updated and not because the pos_by_pos_pattern is wrong.