### PR TITLE
Minor: importing new utilities packages instead of deprecated ones

### DIFF
--- a/chapter1_transformers/instructions/pages/01_[1.1]_Transformer_from_Scratch.py
+++ b/chapter1_transformers/instructions/pages/01_[1.1]_Transformer_from_Scratch.py
@@ -128,7 +128,8 @@ import sys
 import einops
 from dataclasses import dataclass
 from transformer_lens import HookedTransformer
-from transformer_lens.utils import gelu_new, tokenize_and_concatenate
+from transformer_lens.utilities.activation_functions import gelu_new
+from transformer_lens.utilities.tokenize_utils import tokenize_and_concatenate
 import torch as t
 from torch import Tensor
 import torch.nn as nn


### PR DESCRIPTION
Super minor change, I just had an issue with my typechecker mypy:
[HF deprecated utils](https://transformerlensorg.github.io/TransformerLens/generated/code/transformer_lens.utils.html), but redirected it automatically. It works fine at runtime, but in my case, mypy throws  an error when importing using the deprecated transformer_utils package
`Module "transformer_lens.utils" has no attribute "tokenize_and_concatenate"`
Had to update the import statements for the error to stop.